### PR TITLE
Update enhance_struc for scalar structure levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     dplyr,
     glue,
     glyparse (>= 0.5.3),
-    glyrepr (>= 0.10.0),
+    glyrepr (>= 0.10.1.9000),
     glymotif,
     glydb (>= 0.4.0),
     purrr,
@@ -38,3 +38,5 @@ Imports:
 VignetteBuilder: knitr
 Depends:
     R (>= 4.1)
+Remotes:  
+    glycoverse/glyrepr

--- a/R/enhance-struc.R
+++ b/R/enhance-struc.R
@@ -66,11 +66,11 @@ enhance_struc <- function(
 
   if (all(is.na(strucs))) {
     if (return_best) {
-      return(glyrepr::glycan_structure(rep(NA_character_, length(strucs))))
+      return(strucs)
     }
     return(tibble::tibble(
-      raw = glyrepr::glycan_structure(),
-      enhanced = glyrepr::glycan_structure()
+      raw = strucs,
+      enhanced = strucs
     ))
   }
 

--- a/R/enhance-struc.R
+++ b/R/enhance-struc.R
@@ -1,10 +1,11 @@
 #' Enhance glycan structure
 #'
-#' Given a glycan structure of any resolution level (see [glyrepr::get_structure_level()] for details),
-#' this function gives all possible glycan structures of higher resolution level.
+#' Given a glycan structure vector of any resolution level (see
+#' [glyrepr::get_structure_level()] for details), this function gives all
+#' possible glycan structures of higher resolution level.
 #'
-#' The target resolution level is determined from `db`. All structures in `db` must be at the same level.
-#' When `db` is NULL, the default [glydb::glydb_structures()] at "intact" level is used.
+#' The target resolution level is determined from `db`. When `db` is NULL,
+#' the default [glydb::glydb_structures()] at "intact" level is used.
 #'
 #' @param strucs A [glyrepr::glycan_structure()] vector,
 #'   or a character vector of glycan structure strings supported by [glyparse::auto_parse()].
@@ -12,7 +13,6 @@
 #'   Glycan structures with level lower than the level of `db` will be enhanced to that level.
 #' @param db A [glydb::glydb_structures()] vector,
 #'   or a character vector of glycan structure strings supported by [glyparse::auto_parse()].
-#'   All structures in `db` must be at the same resolution level.
 #'   If not provided, a default structure vector is loaded from [glydb::glydb_structures()]
 #'   at "intact" level.
 #' @param return_best Logical. If `TRUE`, only return the best matching structure
@@ -54,48 +54,46 @@ enhance_struc <- function(
   db <- .prepare_struc_db(db)
   .check_return_best_arg(db, return_best)
 
-  # Determine target level from db
-  db_struc_levels <- glyrepr::get_structure_level(db)
-  unique_levels <- unique(db_struc_levels)
-  if (length(unique_levels) > 1) {
-    cli::cli_abort(c(
-      "All structures in `db` must have the same structure level.",
-      "x" = "Found {length(unique_levels)} different levels: {.val {unique_levels}}."
+  if (length(strucs) == 0) {
+    if (return_best) {
+      return(glyrepr::glycan_structure())
+    }
+    return(tibble::tibble(
+      raw = glyrepr::glycan_structure(),
+      enhanced = glyrepr::glycan_structure()
     ))
   }
-  to_level <- unique_levels[1]
+
+  if (all(is.na(strucs))) {
+    if (return_best) {
+      return(glyrepr::glycan_structure(rep(NA_character_, length(strucs))))
+    }
+    return(tibble::tibble(
+      raw = glyrepr::glycan_structure(),
+      enhanced = glyrepr::glycan_structure()
+    ))
+  }
 
   # Define level ranks (higher number means higher resolution)
   level_ranks <- c("basic" = 1, "topological" = 2, "partial" = 3, "intact" = 4)
 
+  # glyrepr::get_structure_level() returns a scalar for the whole vector.
+  to_level <- glyrepr::get_structure_level(db)
   target_rank <- level_ranks[[to_level]]
-  struc_levels <- glyrepr::get_structure_level(strucs)
-  struc_ranks <- level_ranks[struc_levels]
+  struc_level <- glyrepr::get_structure_level(strucs)
+  struc_rank <- level_ranks[[struc_level]]
 
   # Create a dataframe to track original IDs
   strucs_df <- tibble::tibble(
     raw = strucs,
-    row_id = seq_along(strucs),
-    rank = struc_ranks
+    row_id = seq_along(strucs)
   )
 
-  # Identify structures to enhance
-  keep_df <- strucs_df |> dplyr::filter(.data$rank >= target_rank)
-  enhance_df <- strucs_df |> dplyr::filter(.data$rank < target_rank)
-
-  res_keep <- NULL
-  res_enhanced <- NULL
-
-  # Process structures to keep
-  if (nrow(keep_df) > 0) {
-    res_keep <- keep_df |>
-      dplyr::select(all_of(c("raw", "row_id"))) |>
+  if (struc_rank >= target_rank) {
+    res <- strucs_df |>
       dplyr::mutate(enhanced = .data$raw)
-  }
-
-  # Process structures to enhance
-  if (nrow(enhance_df) > 0) {
-    to_enhance <- enhance_df$raw
+  } else {
+    to_enhance <- strucs_df$raw
     # Check matches
     # db are targets (glycans), to_enhance are patterns (motifs)
     matches <- glymotif::have_motifs(db, to_enhance, alignments = "whole")
@@ -104,7 +102,7 @@ enhance_struc <- function(
     # For return_best=FALSE: one row per match
     if (return_best) {
       # Build result for each pattern - one best match or NA
-      res_list <- lapply(seq_along(to_enhance), function(i) {
+      res_list <- purrr::map(seq_along(to_enhance), function(i) {
         col_matches <- which(matches[, i])
         if (length(col_matches) > 0) {
           # Find best match by confidence
@@ -113,18 +111,18 @@ enhance_struc <- function(
           tibble::tibble(
             raw = to_enhance[i],
             enhanced = db[best_col],
-            row_id = enhance_df$row_id[i]
+            row_id = strucs_df$row_id[i]
           )
         } else {
           # No match - NA
           tibble::tibble(
             raw = to_enhance[i],
             enhanced = glyrepr::glycan_structure(NA),
-            row_id = enhance_df$row_id[i]
+            row_id = strucs_df$row_id[i]
           )
         }
       })
-      res_enhanced <- dplyr::bind_rows(res_list)
+      res <- dplyr::bind_rows(res_list)
     } else {
       # matches: rows=db, cols=to_enhance
       match_indices <- which(matches, arr.ind = TRUE)
@@ -132,18 +130,18 @@ enhance_struc <- function(
       if (nrow(match_indices) > 0) {
         # match_indices[, "col"] are indices into to_enhance
         # match_indices[, "row"] are indices into db
-        matched_row_ids <- enhance_df$row_id[match_indices[, "col"]]
-        matched_raw <- enhance_df$raw[match_indices[, "col"]]
+        matched_row_ids <- strucs_df$row_id[match_indices[, "col"]]
+        matched_raw <- strucs_df$raw[match_indices[, "col"]]
         matched_enhanced <- db[match_indices[, "row"]]
 
-        res_enhanced <- tibble::tibble(
+        res <- tibble::tibble(
           raw = matched_raw,
           enhanced = matched_enhanced,
           row_id = matched_row_ids
         )
       } else {
         # No matches found
-        res_enhanced <- tibble::tibble(
+        res <- tibble::tibble(
           raw = to_enhance[integer(0)],
           enhanced = db[integer(0)],
           row_id = integer(0)
@@ -152,8 +150,7 @@ enhance_struc <- function(
     }
   }
 
-  # Combine results
-  res <- dplyr::bind_rows(res_keep, res_enhanced) |>
+  res <- res |>
     dplyr::arrange(.data$row_id) |>
     dplyr::select(all_of(c("raw", "enhanced", "row_id")))
 

--- a/R/enhance-struc.R
+++ b/R/enhance-struc.R
@@ -9,12 +9,12 @@
 #'
 #' @param strucs A [glyrepr::glycan_structure()] vector,
 #'   or a character vector of glycan structure strings supported by [glyparse::auto_parse()].
-#'   Glycan structures with level higher or same as the level of `db` will be returned as is.
-#'   Glycan structures with level lower than the level of `db` will be enhanced to that level.
 #' @param db A [glydb::glydb_structures()] vector,
 #'   or a character vector of glycan structure strings supported by [glyparse::auto_parse()].
 #'   If not provided, a default structure vector is loaded from [glydb::glydb_structures()]
 #'   at "intact" level.
+#'   If `db` has a lower or equal resolution level than `strucs`,
+#'   the result will be the same as `strucs` (no enhancement).
 #' @param return_best Logical. If `TRUE`, only return the best matching structure
 #'   (highest confidence) for each input structure. Requires `db` to have a
 #'   `confidence` attribute. Use [glydb::glydb_structures()] for `db` to enable this feature.

--- a/man/enhance_struc.Rd
+++ b/man/enhance_struc.Rd
@@ -8,14 +8,14 @@ enhance_struc(strucs, db = NULL, return_best = FALSE)
 }
 \arguments{
 \item{strucs}{A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector,
-or a character vector of glycan structure strings supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-Glycan structures with level higher or same as the level of \code{db} will be returned as is.
-Glycan structures with level lower than the level of \code{db} will be enhanced to that level.}
+or a character vector of glycan structure strings supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.}
 
 \item{db}{A \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}} vector,
 or a character vector of glycan structure strings supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
 If not provided, a default structure vector is loaded from \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}}
-at "intact" level.}
+at "intact" level.
+If \code{db} has a lower or equal resolution level than \code{strucs},
+the result will be the same as \code{strucs} (no enhancement).}
 
 \item{return_best}{Logical. If \code{TRUE}, only return the best matching structure
 (highest confidence) for each input structure. Requires \code{db} to have a

--- a/man/enhance_struc.Rd
+++ b/man/enhance_struc.Rd
@@ -14,7 +14,6 @@ Glycan structures with level lower than the level of \code{db} will be enhanced 
 
 \item{db}{A \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}} vector,
 or a character vector of glycan structure strings supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.
-All structures in \code{db} must be at the same resolution level.
 If not provided, a default structure vector is loaded from \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}}
 at "intact" level.}
 
@@ -37,12 +36,13 @@ as multiple rows in the result.
 }
 }
 \description{
-Given a glycan structure of any resolution level (see \code{\link[glyrepr:get_structure_level]{glyrepr::get_structure_level()}} for details),
-this function gives all possible glycan structures of higher resolution level.
+Given a glycan structure vector of any resolution level (see
+\code{\link[glyrepr:get_structure_level]{glyrepr::get_structure_level()}} for details), this function gives all
+possible glycan structures of higher resolution level.
 }
 \details{
-The target resolution level is determined from \code{db}. All structures in \code{db} must be at the same level.
-When \code{db} is NULL, the default \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}} at "intact" level is used.
+The target resolution level is determined from \code{db}. When \code{db} is NULL,
+the default \code{\link[glydb:glydb_structures]{glydb::glydb_structures()}} at "intact" level is used.
 }
 \examples{
 # From topological level to intact level

--- a/tests/testthat/test-enhance-struc.R
+++ b/tests/testthat/test-enhance-struc.R
@@ -87,7 +87,7 @@ test_that("enhance_struc accepts empty structures", {
 test_that("enhance_struc accepts all-NA structures", {
   db_intact <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
   attr(db_intact, "confidence") <- 1
-  input_na <- glyrepr::glycan_structure(NA)
+  input_na <- c(glyrepr::glycan_structure(NA), glyrepr::glycan_structure(NA))
 
   res <- enhance_struc(input_na, db = db_intact)
   best <- enhance_struc(input_na, db = db_intact, return_best = TRUE)
@@ -95,11 +95,11 @@ test_that("enhance_struc accepts all-NA structures", {
   expect_equal(
     res,
     tibble::tibble(
-      raw = glyrepr::glycan_structure(),
-      enhanced = glyrepr::glycan_structure()
+      raw = input_na,
+      enhanced = input_na
     )
   )
-  expect_equal(best, glyrepr::glycan_structure(NA))
+  expect_equal(best, input_na)
 })
 
 test_that("enhance_struc works with multiple glycans", {

--- a/tests/testthat/test-enhance-struc.R
+++ b/tests/testthat/test-enhance-struc.R
@@ -69,6 +69,39 @@ test_that("enhance_struc returns empty result when no match found", {
   expect_equal(res$enhanced, glyrepr::glycan_structure())
 })
 
+test_that("enhance_struc accepts empty structures", {
+  db_intact <- "Gal(b1-3)GalNAc(a1-"
+  input_empty <- glyrepr::glycan_structure()
+
+  res <- enhance_struc(input_empty, db = db_intact)
+
+  expect_equal(
+    res,
+    tibble::tibble(
+      raw = glyrepr::glycan_structure(),
+      enhanced = glyrepr::glycan_structure()
+    )
+  )
+})
+
+test_that("enhance_struc accepts all-NA structures", {
+  db_intact <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  attr(db_intact, "confidence") <- 1
+  input_na <- glyrepr::glycan_structure(NA)
+
+  res <- enhance_struc(input_na, db = db_intact)
+  best <- enhance_struc(input_na, db = db_intact, return_best = TRUE)
+
+  expect_equal(
+    res,
+    tibble::tibble(
+      raw = glyrepr::glycan_structure(),
+      enhanced = glyrepr::glycan_structure()
+    )
+  )
+  expect_equal(best, glyrepr::glycan_structure(NA))
+})
+
 test_that("enhance_struc works with multiple glycans", {
   db_intact <- c(
     "GalNAc(a1-",
@@ -178,16 +211,34 @@ test_that("enhance_struc works with db=NULL (regression: confidences undefined)"
   expect_gt(nrow(result), 0)
 })
 
-test_that("enhance_struc errors with mixed levels in db", {
-  db_mixed <- c(
-    "Gal(b1-3)GalNAc(a1-", # intact level
-    "Gal(??-?)GalNAc(??-" # topological level
+test_that("enhance_struc uses scalar db structure level", {
+  db_partial <- c(
+    "Gal(??-?)GalNAc(??-",
+    "Gal(b1-3)GalNAc(a1-"
   )
-  input <- "Hex(??-?)HexNAc(??-"
-  expect_error(
-    enhance_struc(input, db = db_mixed),
-    "must have the same structure level"
+  input_basic <- "Hex(??-?)HexNAc(??-"
+
+  res <- enhance_struc(input_basic, db = db_partial)
+
+  expect_equal(
+    as.character(res$enhanced),
+    c("Gal(??-?)GalNAc(??-", "Gal(b1-3)GalNAc(a1-")
   )
+})
+
+test_that("enhance_struc uses scalar input structure level", {
+  db_intact <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  attr(db_intact, "confidence") <- 1
+  input_partial <- c(
+    "Gal(??-?)GalNAc(??-",
+    "Gal(b1-4)GalNAc(a1-"
+  )
+
+  res <- enhance_struc(input_partial, db = db_intact, return_best = TRUE)
+
+  expect_equal(length(res), 2)
+  expect_equal(as.character(res[1]), "Gal(b1-3)GalNAc(a1-")
+  expect_true(is.na(res[2]))
 })
 
 test_that("enhance_struc with return_best=TRUE returns NA for no match", {


### PR DESCRIPTION
## Summary
- Update `enhance_struc()` to work with the scalar `glyrepr::get_structure_level()` API
- Remove the obsolete assumption that structure levels are checked element-wise within a vector
- Add regression coverage for empty and all-`NA` structure inputs
- Refresh the generated documentation for `enhance_struc()`

## Testing
- Ran the `enhance-struc` test file locally
- Ran the full `testthat` suite and confirmed all tests passed