### PR TITLE
Use glydb_data before GlycanFormatConverter fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyanno (development version)
 
+## Minor improvements and bug fixes
+
+* `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures.
+
 # glyanno 0.5.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Minor improvements and bug fixes
 
-* `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures.
+* `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 
 # glyanno 0.5.0
 

--- a/R/struc-to-glytoucan.R
+++ b/R/struc-to-glytoucan.R
@@ -1,12 +1,15 @@
 #' Assign GlyTouCan accessions to glycan structures
 #'
-#' This function takes a vector of glycan structures and returns the corresponding GlyTouCan accessions.
-#' Under the hood, it uses the GlycanFormatConverter API maintained by the Glycosmos project.
+#' This function takes a vector of glycan structures and returns the
+#' corresponding GlyTouCan accessions. It first looks up structures from
+#' [glydb::glydb_data], then uses the GlycanFormatConverter API maintained by
+#' the Glycosmos project for structures not found locally.
 #'
 #' @details
 #' For "topological" structures (e.g., "Gal(??-?)GalNAc(??-"),
-#' this function will first call [fill_anomer_pos()] to fill in the missing anomeric positions before querying the API.
-#' This is necessary because all glycan structures in GlyTouCan must have defined anomeric positions.
+#' this function will first call [fill_anomer_pos()] to fill in the missing
+#' anomeric positions before looking up accessions. This is necessary because
+#' all glycan structures in GlyTouCan must have defined anomeric positions.
 #'
 #' @param strucs A [glyrepr::glycan_structure()] vector,
 #'   or a character vector of glycan text representations supported by [glyparse::auto_parse()].
@@ -26,7 +29,16 @@ struc_to_glytoucan <- function(strucs) {
     return(accessions)
   }
 
-  iupacs <- glyrepr::structure_to_iupac(strucs[!missing_strucs])
+  known_strucs <- !missing_strucs
+  local_accessions <- local_struc_glytoucan_accessions(strucs[known_strucs])
+  accessions[known_strucs] <- local_accessions
+  fallback_strucs <- known_strucs & is.na(accessions)
+
+  if (!any(fallback_strucs)) {
+    return(accessions)
+  }
+
+  iupacs <- glyrepr::structure_to_iupac(strucs[fallback_strucs])
   base_url <- "https://api.glycosmos.org/glycanformatconverter/2.8.2/iupaccondensed2wurcs/"
   encoded_iupacs <- purrr::map_chr(
     iupacs,
@@ -41,7 +53,7 @@ struc_to_glytoucan <- function(strucs) {
     purrr::map(httr2::req_retry, max_tries = 2)
   resps <- purrr::map(reqs, httr2::req_perform)
 
-  accessions[!missing_strucs] <- purrr::map_chr(resps, function(resp) {
+  accessions[fallback_strucs] <- purrr::map_chr(resps, function(resp) {
     if (httr2::resp_status(resp) == 200) {
       content <- httr2::resp_body_json(resp)
       if (!is.null(content$id)) {
@@ -51,4 +63,19 @@ struc_to_glytoucan <- function(strucs) {
     NA_character_
   })
   accessions
+}
+
+#' Look up glycan structure accessions from glydb data
+#'
+#' Match glycan structures to bundled `glydb_data` GlyTouCan accessions while
+#' preserving input order and unresolved positions.
+#'
+#' @param strucs A [glyrepr::glycan_structure()] vector.
+#'
+#' @returns A character vector of GlyTouCan accessions, with `NA` for structures
+#'   not available in [glydb::glydb_data].
+#' @noRd
+local_struc_glytoucan_accessions <- function(strucs) {
+  data_position <- match(strucs, glydb::glydb_data$glycan_structure)
+  glydb::glydb_data$glytoucan_ac[data_position]
 }

--- a/man/struc_to_glytoucan.Rd
+++ b/man/struc_to_glytoucan.Rd
@@ -16,11 +16,14 @@ A character vector of GlyTouCan accessions corresponding to the input glycan str
 If a structure cannot be converted to a GlyTouCan accession, the corresponding entry will be \code{NA}.
 }
 \description{
-This function takes a vector of glycan structures and returns the corresponding GlyTouCan accessions.
-Under the hood, it uses the GlycanFormatConverter API maintained by the Glycosmos project.
+This function takes a vector of glycan structures and returns the
+corresponding GlyTouCan accessions. It first looks up structures from
+\link[glydb:glydb_data]{glydb::glydb_data}, then uses the GlycanFormatConverter API maintained by
+the Glycosmos project for structures not found locally.
 }
 \details{
 For "topological" structures (e.g., "Gal(??-?)GalNAc(??-"),
-this function will first call \code{\link[=fill_anomer_pos]{fill_anomer_pos()}} to fill in the missing anomeric positions before querying the API.
-This is necessary because all glycan structures in GlyTouCan must have defined anomeric positions.
+this function will first call \code{\link[=fill_anomer_pos]{fill_anomer_pos()}} to fill in the missing
+anomeric positions before looking up accessions. This is necessary because
+all glycan structures in GlyTouCan must have defined anomeric positions.
 }

--- a/tests/testthat/test-struc-to-glytoucan.R
+++ b/tests/testthat/test-struc-to-glytoucan.R
@@ -23,8 +23,8 @@ test_that("struc_to_glytoucan maps successful responses to accessions", {
   )
 
   strucs <- glyrepr::as_glycan_structure(c(
-    "Gal(b1-3)GalNAc(a1-",
-    "GalNAc(a1-"
+    "Man(b1-2)Gal(a1-",
+    "Gal(b1-5)Man(a1-"
   ))
   accessions <- suppressMessages(struc_to_glytoucan(strucs))
 
@@ -48,8 +48,8 @@ test_that("struc_to_glytoucan returns NA for unsuccessful responses", {
   )
 
   strucs <- glyrepr::as_glycan_structure(c(
-    "Gal(b1-3)GalNAc(a1-",
-    "GalNAc(a1-"
+    "Man(b1-2)Gal(a1-",
+    "Gal(b1-5)Man(a1-"
   ))
   accessions <- suppressMessages(struc_to_glytoucan(strucs))
 
@@ -68,7 +68,7 @@ test_that("struc_to_glytoucan skips NA structures before building requests", {
 
   strucs <- c(
     glyrepr::glycan_structure(NA),
-    glyrepr::as_glycan_structure("GalNAc(a1-"),
+    glyrepr::as_glycan_structure("Man(b1-2)Gal(a1-"),
     glyrepr::glycan_structure(NA)
   )
   accessions <- suppressMessages(struc_to_glytoucan(strucs))
@@ -76,6 +76,50 @@ test_that("struc_to_glytoucan skips NA structures before building requests", {
   expect_equal(accessions, c(NA_character_, "G00004MO", NA_character_))
   expect_equal(length(performed_urls), 1)
   expect_false(any(grepl("NA$", performed_urls)))
+})
+
+test_that("struc_to_glytoucan uses glydb_data before API fallback", {
+  local_structure <- glydb::glydb_data$glycan_structure[1]
+  performed_urls <- character()
+
+  local_mocked_bindings(
+    req_perform = function(req) {
+      performed_urls <<- c(performed_urls, req$url)
+      glytoucan_response(body = '{"id":"G00004MO"}')
+    },
+    .package = "httr2"
+  )
+
+  strucs <- c(
+    glyrepr::as_glycan_structure("Man(b1-2)Gal(a1-"),
+    local_structure
+  )
+  accessions <- suppressMessages(struc_to_glytoucan(strucs))
+
+  expect_equal(accessions, c("G00004MO", glydb::glydb_data$glytoucan_ac[[1]]))
+  expect_equal(length(performed_urls), 1)
+  expect_true(grepl("Man", performed_urls, fixed = TRUE))
+})
+
+test_that("struc_to_glytoucan does not request structures present in glydb_data", {
+  local_structures <- glydb::glydb_data$glycan_structure[1:2]
+  performed_urls <- character()
+
+  local_mocked_bindings(
+    req_perform = function(req) {
+      performed_urls <<- c(performed_urls, req$url)
+      stop(
+        "No request should be performed for local structures.",
+        call. = FALSE
+      )
+    },
+    .package = "httr2"
+  )
+
+  accessions <- suppressMessages(struc_to_glytoucan(local_structures))
+
+  expect_equal(accessions, glydb::glydb_data$glytoucan_ac[1:2])
+  expect_equal(performed_urls, character())
 })
 
 test_that("struc_to_glytoucan accepts character structure input", {
@@ -86,7 +130,7 @@ test_that("struc_to_glytoucan accepts character structure input", {
     .package = "httr2"
   )
 
-  accessions <- suppressMessages(struc_to_glytoucan("GalNAc(a1-"))
+  accessions <- suppressMessages(struc_to_glytoucan("Man(b1-2)Gal(a1-"))
 
   expect_equal(accessions, "G00003MO")
 })


### PR DESCRIPTION
## Summary
- Make `struc_to_glytoucan()` resolve structures through bundled `glydb::glydb_data` before making online GlycanFormatConverter requests.
- Keep the existing API fallback for structures absent from the bundled data.
- Add regression coverage for mixed local/API lookup and all-local no-request behavior.
- Update `NEWS.md` with the finalized `(#14)` entry.

## Verification
- `Rscript -e 'devtools::document(); devtools::test(filter = "struc-to-glytoucan"); devtools::test()'`
  - focused `struc-to-glytoucan`: 14 passed
  - full suite: 151 passed, 0 failed, 0 warnings, 0 skipped