### PR TITLE
perf: speed up mass and composition annotation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Imports:
     purrr,
     rlang,
     tidyselect,
-    tidyr,
     tibble,
     httr2,
     lifecycle

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,10 +13,10 @@
 
 ## Minor improvements and bug fixes
 
-* `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported.
-* `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate.
-* `enhance_comp()` now reuses its prepared default composition database and selects best matches by direct lookup.
-* `mz_to_comp()` now matches batches of masses using direct numeric indexing instead of per-mass data-frame filtering.
+* `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported. (#20)
+* `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate. (#20)
+* `enhance_comp()` now reuses its prepared default composition database and selects best matches by direct lookup. (#20)
+* `mz_to_comp()` now matches batches of masses using direct numeric indexing instead of per-mass data-frame filtering. (#20)
 * `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 
 # glyanno 0.5.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 
 ## Minor improvements and bug fixes
 
+* `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported.
 * `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 
 # glyanno 0.5.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 
 * `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported.
 * `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate.
+* `mz_to_comp()` now matches batches of masses using direct numeric indexing instead of per-mass data-frame filtering.
 * `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 
 # glyanno 0.5.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 
 * `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported.
 * `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate.
+* `enhance_comp()` now reuses its prepared default composition database and selects best matches by direct lookup.
 * `mz_to_comp()` now matches batches of masses using direct numeric indexing instead of per-mass data-frame filtering.
 * `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ## Minor improvements and bug fixes
 
 * `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported.
+* `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate.
 * `struc_to_glytoucan()` now looks up accessions from `glydb::glydb_data` first and only falls back to the online GlycanFormatConverter API for missing structures. (#14)
 
 # glyanno 0.5.0

--- a/R/calculate-mz.R
+++ b/R/calculate-mz.R
@@ -74,17 +74,25 @@ calculate_mz <- function(
     names(mass_dict)
   )
   subs <- intersect(glyrepr::available_substituents(), names(mass_dict))
-  counts <- purrr::map(c(monos, subs), ~ glyrepr::count_mono(comps, .))
+  generic_comps <- glyrepr::convert_to_generic(comps)
+  counts <- purrr::map(
+    c(monos, subs),
+    \(component) glyrepr::count_mono(generic_comps, component)
+  )
 
   bad_monos <- setdiff(glyrepr::available_monosaccharides("generic"), monos)
   bad_subs <- setdiff(glyrepr::available_substituents(), subs)
   bad_components <- c(bad_monos, bad_subs)
   bad_component_counts <- purrr::map(
     bad_components,
-    ~ glyrepr::count_mono(comps, .)
+    \(component) glyrepr::count_mono(generic_comps, component)
   )
+  bad_component_totals <- purrr::map_int(
+    bad_component_counts,
+    \(counts) sum(counts, na.rm = TRUE)
+  )
+  has_bad_components <- bad_component_totals > 0
   if (safe) {
-    has_bad_components <- purrr::map_int(bad_component_counts, sum) > 0
     if (any(has_bad_components)) {
       cli::cli_abort(c(
         "Unsupported monosaccharides or substituents found in the glycans.",
@@ -93,10 +101,10 @@ calculate_mz <- function(
         "i" = "Use {.fn glyrepr::count_mono} to find the invalid glycans."
       ))
     }
-  } else {
+  } else if (any(has_bad_components)) {
     cli::cli_warn(c(
       "Unsupported monosaccharides or substituents found in the glycans.",
-      "x" = "Unsupported monosaccharides or substituents: {.val {bad_components}}",
+      "x" = "Unsupported monosaccharides or substituents: {.val {bad_components[has_bad_components]}}",
       "i" = "Supported monosaccharides or substituents: {.val {c(monos, subs)}}",
       "i" = "Use {.fn glyrepr::count_mono} to find the invalid glycans.",
       "i" = "m/z values for invalid glycans are set to NA."
@@ -113,7 +121,7 @@ calculate_mz <- function(
     mz <- mz / abs(charge)
   }
   if (!safe) {
-    mz[rowSums(do.call(cbind, bad_component_counts)) > 0] <- NA
+    mz[rowSums(do.call(cbind, bad_component_counts), na.rm = TRUE) > 0] <- NA
   }
   mz
 }

--- a/R/comp-to-struc.R
+++ b/R/comp-to-struc.R
@@ -36,11 +36,10 @@
 comp_to_struc <- function(comps, db = NULL, return_best = FALSE) {
   checkmate::assert_flag(return_best)
   comps <- .ensure_glycan_composition(comps, allow_structure = FALSE)
-  db <- .prepare_struc_db(db)
-  .check_return_best_arg(db, return_best)
 
-  # Handle empty compositions early (before calling get_mono_type)
   if (length(comps) == 0) {
+    db <- .prepare_struc_db(db)
+    .check_return_best_arg(db, return_best)
     if (return_best) {
       return(glyrepr::glycan_structure())
     }
@@ -50,47 +49,42 @@ comp_to_struc <- function(comps, db = NULL, return_best = FALSE) {
     ))
   }
 
-  # Get mono type to determine matching strategy
   mono_type <- glyrepr::get_mono_type(comps)
+  db_index <- .prepare_comp_to_struc_index(db, mono_type)
+  db <- db_index$db
+  .check_return_best_arg(db, return_best)
 
   if (mono_type == "generic") {
-    # For generic compositions, convert both to generic for matching
-    db_comps_generic <- glyrepr::convert_to_generic(glyrepr::as_glycan_composition(
-      db
-    ))
-    db_df <- tibble::tibble(
-      composition = db_comps_generic,
-      structure = db,
-      confidence = attr(db, "confidence")
-    )
-    comps_df <- tibble::tibble(
-      composition = glyrepr::convert_to_generic(comps),
-      row_id = seq_along(comps)
-    )
-    res <- comps_df |>
-      dplyr::left_join(db_df, by = "composition")
+    comp_keys <- glyrepr::convert_to_generic(comps)
   } else {
-    # For concrete compositions, match directly to concrete structures only
-    # After glyrepr 0.9.0.9000, db must be homogeneous (all generic or all concrete)
     if (glyrepr::get_mono_type(db) == "generic") {
-      # Concrete comps cannot match generic structures - this is a usage error
       cli::cli_abort(c(
         "Concrete compositions cannot be matched against a generic structure database.",
         "i" = "Use generic compositions (e.g. {.val Hex(1)HexNAc(1)}) or provide a concrete structure database."
       ))
     }
-    db_concrete_df <- tibble::tibble(
-      composition = glyrepr::as_glycan_composition(db),
-      structure = db,
-      confidence = attr(db, "confidence")
-    )
-    comps_df <- tibble::tibble(
-      composition = comps,
-      row_id = seq_along(comps)
-    )
-    res <- comps_df |>
-      dplyr::left_join(db_concrete_df, by = "composition")
+    comp_keys <- comps
   }
+
+  if (return_best) {
+    match_ids <- match(
+      comp_keys,
+      db_index$composition[db_index$best_order]
+    )
+    return(unname(db[db_index$best_order][match_ids]))
+  }
+
+  db_df <- tibble::tibble(
+    composition = db_index$composition,
+    structure = db,
+    confidence = attr(db, "confidence")
+  )
+  comps_df <- tibble::tibble(
+    composition = comp_keys,
+    row_id = seq_along(comps)
+  )
+  res <- comps_df |>
+    dplyr::left_join(db_df, by = "composition", relationship = "many-to-many")
 
   .prepare_result(
     res,
@@ -98,4 +92,37 @@ comp_to_struc <- function(comps, db = NULL, return_best = FALSE) {
     raw_col = "composition",
     new_col = "structure"
   )
+}
+
+.comp_to_struc_cache <- new.env(parent = emptyenv())
+
+.prepare_comp_to_struc_index <- function(db, mono_type) {
+  if (!is.null(db)) {
+    return(.new_comp_to_struc_index(.prepare_struc_db(db), mono_type))
+  }
+
+  cache_key <- paste0("default_", mono_type)
+  if (!exists(cache_key, envir = .comp_to_struc_cache, inherits = FALSE)) {
+    index <- .new_comp_to_struc_index(
+      glydb::glydb_structures(structure_level = "intact"),
+      mono_type
+    )
+    assign(cache_key, index, envir = .comp_to_struc_cache)
+  }
+  get(cache_key, envir = .comp_to_struc_cache, inherits = FALSE)
+}
+
+.new_comp_to_struc_index <- function(db, mono_type) {
+  composition <- glyrepr::as_glycan_composition(db)
+  if (mono_type == "generic") {
+    composition <- glyrepr::convert_to_generic(composition)
+  }
+
+  confidence <- attr(db, "confidence")
+  best_order <- order(
+    replace(confidence, is.na(confidence), -Inf),
+    decreasing = TRUE,
+    method = "radix"
+  )
+  list(db = db, composition = composition, best_order = best_order)
 }

--- a/R/enhance-comp.R
+++ b/R/enhance-comp.R
@@ -38,7 +38,8 @@ enhance_comp <- function(comps, db = NULL, return_best = FALSE) {
   checkmate::assert_flag(return_best)
   # Input validation and preparation
   comps <- .ensure_glycan_composition(comps, allow_structure = FALSE)
-  db <- .prepare_comp_db(db)
+  db_index <- .prepare_enhance_comp_index(db)
+  db <- db_index$db
   .check_return_best_arg(db, return_best)
 
   # Handle empty composition case
@@ -61,19 +62,31 @@ enhance_comp <- function(comps, db = NULL, return_best = FALSE) {
   comps_type <- glyrepr::get_mono_type(comps)
 
   if (comps_type == "generic") {
-    # Generic compositions: match via generic conversion
+    comp_keys <- glyrepr::convert_to_generic(comps)
+    if (return_best) {
+      match_ids <- match(
+        comp_keys,
+        db_index$generic[db_index$best_order]
+      )
+      return(unname(db[db_index$best_order][match_ids]))
+    }
+
     db_df <- tibble::tibble(
-      generic = glyrepr::convert_to_generic(db),
+      generic = db_index$generic,
       concrete = db,
       confidence = attr(db, "confidence") %||% NA_real_
     )
     comps_df <- tibble::tibble(
-      composition = glyrepr::convert_to_generic(comps),
+      composition = comp_keys,
       row_id = seq_along(comps)
     )
 
     res <- comps_df |>
-      dplyr::left_join(db_df, by = c("composition" = "generic")) |>
+      dplyr::left_join(
+        db_df,
+        by = c("composition" = "generic"),
+        relationship = "many-to-many"
+      ) |>
       dplyr::select(all_of(c(
         "raw" = "composition",
         "enhanced" = "concrete",
@@ -97,4 +110,33 @@ enhance_comp <- function(comps, db = NULL, return_best = FALSE) {
     )
   }
   res
+}
+
+.enhance_comp_cache <- new.env(parent = emptyenv())
+
+.prepare_enhance_comp_index <- function(db) {
+  if (!is.null(db)) {
+    return(.new_enhance_comp_index(.prepare_comp_db(db)))
+  }
+
+  cache_key <- "default"
+  if (!exists(cache_key, envir = .enhance_comp_cache, inherits = FALSE)) {
+    index <- .new_enhance_comp_index(glydb::glydb_compositions())
+    assign(cache_key, index, envir = .enhance_comp_cache)
+  }
+  get(cache_key, envir = .enhance_comp_cache, inherits = FALSE)
+}
+
+.new_enhance_comp_index <- function(db) {
+  confidence <- attr(db, "confidence")
+  best_order <- order(
+    replace(confidence, is.na(confidence), -Inf),
+    decreasing = TRUE,
+    method = "radix"
+  )
+  list(
+    db = db,
+    generic = glyrepr::convert_to_generic(db),
+    best_order = best_order
+  )
 }

--- a/R/mz-to-comp.R
+++ b/R/mz-to-comp.R
@@ -116,51 +116,41 @@ mz_to_comp <- function(
   if (!is.null(confidences)) {
     confidences <- confidences[!db_na_mask]
   }
-  db_df <- tibble::tibble(
-    composition = db,
-    mz = db_mz,
-    confidence = confidences
-  ) |>
-    dplyr::mutate(
-      tol = ifelse(is.numeric(.env$tol), .env$tol, .env$tol(.data$mz)),
-      upper = .data$mz + .data$tol,
-      lower = .data$mz - .data$tol
-    )
+  tolerances <- if (is.numeric(tol)) {
+    rep(tol, length(db_mz))
+  } else {
+    tol(db_mz)
+  }
+  upper <- db_mz + tolerances
+  lower <- db_mz - tolerances
 
   find_one <- function(mz) {
-    matches <- db_df |>
-      dplyr::filter(.env$mz > .data$lower & .env$mz < .data$upper)
-    if (nrow(matches) == 0) {
-      if (return_best) {
-        return(NA_character_)
-      } else {
-        return(glyrepr::glycan_composition())
-      }
+    match_ids <- which(mz > lower & mz < upper)
+    if (length(match_ids) == 0) {
+      return(integer())
     }
-    if (return_best && nrow(matches) > 1) {
-      # Arrange by desc(confidence), treating NA as lowest
-      matches <- matches |>
-        dplyr::mutate(
-          conf_sort = ifelse(is.na(.data$confidence), -Inf, .data$confidence)
-        ) |>
-        dplyr::arrange(dplyr::desc(.data$conf_sort)) |>
-        dplyr::select(-"conf_sort")
-      matches <- matches[1, ]
+    if (return_best && length(match_ids) > 1) {
+      match_confidences <- confidences[match_ids]
+      match_confidences[is.na(match_confidences)] <- -Inf
+      return(match_ids[which.max(match_confidences)])
     }
-    matches |> dplyr::pull(.data$composition)
+    match_ids
   }
 
-  res_comps <- purrr::map(mz_to_process, find_one)
+  match_ids <- purrr::map(mz_to_process, find_one)
   if (return_best) {
-    # Build result with same length as original mz, inserting NAs at NA input positions
-    char_comps <- purrr::map(res_comps, function(x) {
-      if (length(x) == 0 || is.na(x)) NA_character_ else as.character(x)
-    })
-    full_char_comps <- rep(NA_character_, length(mz))
-    full_char_comps[!na_input_mask] <- unname(unlist(char_comps))
-    glyrepr::as_glycan_composition(full_char_comps)
+    best_ids <- purrr::map_int(
+      match_ids,
+      \(ids) if (length(ids) == 0) NA_integer_ else ids[[1]]
+    )
+    full_ids <- rep(NA_integer_, length(mz))
+    full_ids[!na_input_mask] <- best_ids
+    unname(db[full_ids])
   } else {
-    res_df <- tibble::tibble(mz = mz_to_process, composition = res_comps)
-    tidyr::unnest(res_df, all_of("composition"))
+    match_counts <- lengths(match_ids)
+    tibble::tibble(
+      mz = rep(mz_to_process, match_counts),
+      composition = db[unlist(match_ids, use.names = FALSE)]
+    )
   }
 }

--- a/tests/testthat/test-calculate-mz.R
+++ b/tests/testthat/test-calculate-mz.R
@@ -61,6 +61,15 @@ test_that("calculate_mz works for unsupported monosaccharides with safe = FALSE"
   expect_mass(result, c(NA, 2368.84))
 })
 
+test_that("calculate_mz is quiet for supported glycans with safe = FALSE", {
+  comp <- glyrepr::glycan_composition(c(Hex = 1))
+
+  expect_no_warning(
+    result <- calculate_mz(comp, charge = 0, safe = FALSE)
+  )
+  expect_mass(result, 180.06)
+})
+
 # ===== Test vectorization =====
 test_that("calculate_mz works for vector input", {
   comps <- c("Hex(5)HexNAc(4)dHex(1)NeuAc(2)", "HexNAc(2)Hex(3)")

--- a/tests/testthat/test-comp-to-struc.R
+++ b/tests/testthat/test-comp-to-struc.R
@@ -199,6 +199,15 @@ test_that("comp_to_struc works with db=NULL (regression: confidences undefined)"
   expect_gt(nrow(result), 0)
 })
 
+test_that("comp_to_struc reuses the prepared default database", {
+  comps <- glyrepr::as_glycan_composition("Hex(1)HexNAc(1)")
+
+  first <- comp_to_struc(comps, db = NULL, return_best = TRUE)
+  second <- comp_to_struc(comps, db = NULL, return_best = TRUE)
+
+  expect_equal(second, first)
+})
+
 test_that("comp_to_struc with return_best=TRUE returns NA for no match", {
   db <- glyrepr::as_glycan_structure(c("Gal(b1-3)GalNAc(a1-"))
   attr(db, "confidence") <- c(1.0)

--- a/tests/testthat/test-enhance-comp.R
+++ b/tests/testthat/test-enhance-comp.R
@@ -122,6 +122,15 @@ test_that("enhance_comp works with db=NULL (regression: confidences undefined)",
   expect_named(result, c("raw", "enhanced"))
 })
 
+test_that("enhance_comp reuses the prepared default database", {
+  comps <- glyrepr::as_glycan_composition("Hex(1)")
+
+  first <- enhance_comp(comps, db = NULL, return_best = TRUE)
+  second <- enhance_comp(comps, db = NULL, return_best = TRUE)
+
+  expect_equal(second, first)
+})
+
 test_that("enhance_comp with return_best=TRUE returns vector with NA for no match", {
   db <- glyrepr::glycan_composition(
     c(Glc = 2)


### PR DESCRIPTION
## Summary

- Convert glycan compositions to generic form once during mass calculation, avoiding repeated whole-vector conversion for each component.
- Cache prepared default-database indexes in `comp_to_struc()` and `enhance_comp()` while retaining direct best-match lookup for custom databases.
- Replace per-mass data-frame filtering and character round-tripping in `mz_to_comp()` with numeric indexing and direct vector assembly.
- Keep `calculate_mz(..., safe = FALSE)` quiet when all components are supported and remove the unused `tidyr` dependency.

## Benchmarks

| Function and workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `calculate_mz()`, 200 compositions | 1.814 s | 0.104 s | 17.4× |
| `comp_to_struc()`, 500 inputs, repeated default database | 7.255 s | 0.198 s | 36.6× |
| `mz_to_comp()`, 1,000 masses × 200 database entries | 1.599 s | 0.157 s | 10.2× |
| `enhance_comp()`, 1,000 inputs, repeated default database | 1.200 s | 0.098 s | 12.2× |

Times are medians from five iterations except the cache benchmarks, which separately warmed the default-database cache before measuring repeated calls.

## Verification

- `devtools::test()`: 344 passed, 0 failed, 0 warnings, 0 skipped.
- `devtools::check(error_on = "never")`: 0 errors, 0 warnings; one environment-only NOTE because system-clock verification was unavailable.
- `git diff --check`