### PR TITLE
fix: preserve duplicated inputs in enhance_struc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 
 ## Minor improvements and bug fixes
 
-* `enhance_struc()` now accepts duplicated input structures, preserves their order and per-occurrence results, and matches each unique non-missing structure only once. (#19)
+* `enhance_struc()` now accepts duplicated input structures, preserves their order and per-occurrence results, and matches each unique non-missing structure only once. (#21)
 * `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported. (#20)
 * `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate. (#20)
 * `enhance_comp()` now reuses its prepared default composition database and selects best matches by direct lookup. (#20)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 
 ## Minor improvements and bug fixes
 
+* `enhance_struc()` now accepts duplicated input structures, preserves their order and per-occurrence results, and matches each unique non-missing structure only once. (#19)
 * `calculate_mz()` now processes vector inputs substantially faster by reusing generic composition conversion, and `safe = FALSE` stays quiet when all components are supported. (#20)
 * `comp_to_struc()` now reuses its prepared default structure database and selects best matches without materializing every candidate. (#20)
 * `enhance_comp()` now reuses its prepared default composition database and selects best matches by direct lookup. (#20)

--- a/R/enhance-struc.R
+++ b/R/enhance-struc.R
@@ -93,59 +93,58 @@ enhance_struc <- function(
       dplyr::mutate(enhanced = .data$raw)
   } else {
     to_enhance <- strucs_df$raw
+    is_missing <- is.na(to_enhance)
+    unique_to_enhance <- unique(to_enhance[!is_missing])
+    unique_ids <- match(
+      as.character(to_enhance),
+      as.character(unique_to_enhance)
+    )
     # Check matches
-    # db are targets (glycans), to_enhance are patterns (motifs)
-    matches <- glymotif::have_motifs(db, to_enhance, alignments = "whole")
+    # db are targets (glycans), unique_to_enhance are patterns (motifs)
+    matches <- glymotif::have_motifs(
+      db,
+      unique_to_enhance,
+      alignments = "whole"
+    )
 
     # For return_best=TRUE: one row per to_enhance, best match or NA
     # For return_best=FALSE: one row per match
     if (return_best) {
-      # Build result for each pattern - one best match or NA
-      res_list <- purrr::map(seq_along(to_enhance), function(i) {
+      # Find one best match or NA for each unique pattern, then restore inputs.
+      best_matches <- purrr::map(seq_along(unique_to_enhance), function(i) {
         col_matches <- which(matches[, i])
         if (length(col_matches) > 0) {
           # Find best match by confidence
           confs <- attr(db, "confidence")[col_matches]
           best_col <- col_matches[which.max(confs)]
-          tibble::tibble(
-            raw = to_enhance[i],
-            enhanced = db[best_col],
-            row_id = strucs_df$row_id[i]
-          )
+          db[best_col]
         } else {
-          # No match - NA
-          tibble::tibble(
-            raw = to_enhance[i],
-            enhanced = glyrepr::glycan_structure(NA),
-            row_id = strucs_df$row_id[i]
-          )
+          glyrepr::glycan_structure(NA)
         }
       })
-      res <- dplyr::bind_rows(res_list)
+      best_matches <- do.call(c, best_matches)
+      res <- tibble::tibble(
+        raw = to_enhance,
+        enhanced = best_matches[unique_ids],
+        row_id = strucs_df$row_id
+      )
     } else {
-      # matches: rows=db, cols=to_enhance
-      match_indices <- which(matches, arr.ind = TRUE)
-
-      if (nrow(match_indices) > 0) {
-        # match_indices[, "col"] are indices into to_enhance
-        # match_indices[, "row"] are indices into db
-        matched_row_ids <- strucs_df$row_id[match_indices[, "col"]]
-        matched_raw <- strucs_df$raw[match_indices[, "col"]]
-        matched_enhanced <- db[match_indices[, "row"]]
-
-        res <- tibble::tibble(
-          raw = matched_raw,
-          enhanced = matched_enhanced,
-          row_id = matched_row_ids
+      # Restore the matches for each original occurrence of a unique pattern.
+      res <- purrr::map_dfr(seq_along(to_enhance), function(i) {
+        if (is_missing[[i]]) {
+          return(tibble::tibble(
+            raw = to_enhance[integer(0)],
+            enhanced = db[integer(0)],
+            row_id = integer(0)
+          ))
+        }
+        db_ids <- which(matches[, unique_ids[[i]]])
+        tibble::tibble(
+          raw = rep(to_enhance[i], length(db_ids)),
+          enhanced = db[db_ids],
+          row_id = rep(strucs_df$row_id[[i]], length(db_ids))
         )
-      } else {
-        # No matches found
-        res <- tibble::tibble(
-          raw = to_enhance[integer(0)],
-          enhanced = db[integer(0)],
-          row_id = integer(0)
-        )
-      }
+      })
     }
   }
 

--- a/tests/testthat/test-calculate-mz.R
+++ b/tests/testthat/test-calculate-mz.R
@@ -76,6 +76,16 @@ test_that("calculate_mz works for vector input", {
   expect_mass(calculate_mz(comps, charge = 0), c(2368.84, 910.33))
 })
 
+test_that("calculate_mz preserves duplicated glycans", {
+  unique_comps <- c("Hex(2)", "Hex(1)")
+  comps <- unique_comps[c(1, 2, 1)]
+
+  result <- calculate_mz(comps, charge = 0)
+  expected <- calculate_mz(unique_comps, charge = 0)[c(1, 2, 1)]
+
+  expect_equal(result, expected)
+})
+
 # ===== Test substituents =====
 test_that("calculate_mz works for compositions with substituents", {
   comp <- glyrepr::glycan_composition(c(Glc = 1, S = 1))

--- a/tests/testthat/test-comp-to-struc.R
+++ b/tests/testthat/test-comp-to-struc.R
@@ -97,13 +97,16 @@ test_that("comp_to_struc handles duplicate compositions", {
     "HexNAc(1)",
     "Hex(1)HexNAc(1)"
   ))
+  attr(db, "confidence") <- c(1, 2)
   result <- comp_to_struc(comps, db) |>
     dplyr::mutate(structure = as.character(structure))
+  best <- comp_to_struc(comps, db, return_best = TRUE)
   expected <- tibble::tibble(
     composition = comps,
     structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-", "Hex(??-?)HexNAc(??-")
   )
   expect_equal(result, expected)
+  expect_equal(as.character(best), expected$structure)
 })
 
 test_that("comp_to_struc accepts empty compositions", {

--- a/tests/testthat/test-enhance-comp.R
+++ b/tests/testthat/test-enhance-comp.R
@@ -54,6 +54,29 @@ test_that("enhance_comp works with generic and compositions", {
   expect_equal(result, expected)
 })
 
+test_that("enhance_comp preserves duplicated compositions", {
+  db <- glyrepr::glycan_composition(
+    c(Glc = 2),
+    c(Gal = 2),
+    c(Glc = 1)
+  )
+  attr(db, "confidence") <- c(1, 2, 3)
+  comps <- glyrepr::as_glycan_composition(c("Hex(2)", "Hex(1)", "Hex(2)"))
+
+  best <- enhance_comp(comps, db, return_best = TRUE)
+  expanded <- enhance_comp(comps, db, return_best = FALSE)
+
+  expect_equal(as.character(best), c("Gal(2)", "Glc(1)", "Gal(2)"))
+  expect_equal(
+    as.character(expanded$raw),
+    c("Hex(2)", "Hex(2)", "Hex(1)", "Hex(2)", "Hex(2)")
+  )
+  expect_equal(
+    as.character(expanded$enhanced),
+    c("Glc(2)", "Gal(2)", "Glc(1)", "Glc(2)", "Gal(2)")
+  )
+})
+
 test_that("enhance_comp works with concrete compositions", {
   comps <- "Gal(1)GalNAc(1)"
   db <- c("Glc(1)GalNAc(1)", "Glc(1)GlcNAc(1)")

--- a/tests/testthat/test-enhance-struc.R
+++ b/tests/testthat/test-enhance-struc.R
@@ -140,6 +140,74 @@ test_that("enhance_struc works with multiple glycans", {
   expect_equal(as.character(res$enhanced), as.character(expected$enhanced))
 })
 
+test_that("enhance_struc restores repeated and missing inputs", {
+  db <- glyrepr::as_glycan_structure(c(
+    "Gal(b1-3)GalNAc(a1-",
+    "Gal(b1-4)GalNAc(a1-",
+    "GalNAc(a1-"
+  ))
+  attr(db, "confidence") <- c(1, 2, 3)
+  strucs <- glyrepr::as_glycan_structure(c(
+    "Hex(??-?)HexNAc(??-",
+    NA,
+    "HexNAc(??-",
+    "Hex(??-?)HexNAc(??-"
+  ))
+
+  best <- enhance_struc(strucs, db = db, return_best = TRUE)
+  expanded <- enhance_struc(strucs, db = db, return_best = FALSE)
+
+  expect_equal(
+    as.character(best),
+    c("Gal(b1-4)GalNAc(a1-", NA, "GalNAc(a1-", "Gal(b1-4)GalNAc(a1-")
+  )
+  expect_equal(
+    as.character(expanded$raw),
+    c(
+      "Hex(??-?)HexNAc(??-",
+      "Hex(??-?)HexNAc(??-",
+      "HexNAc(??-",
+      "Hex(??-?)HexNAc(??-",
+      "Hex(??-?)HexNAc(??-"
+    )
+  )
+  expect_equal(
+    as.character(expanded$enhanced),
+    c(
+      "Gal(b1-3)GalNAc(a1-",
+      "Gal(b1-4)GalNAc(a1-",
+      "GalNAc(a1-",
+      "Gal(b1-3)GalNAc(a1-",
+      "Gal(b1-4)GalNAc(a1-"
+    )
+  )
+})
+
+test_that("enhance_struc matches each unique non-missing input once", {
+  matched_patterns <- NULL
+  local_mocked_bindings(
+    have_motifs = function(glycans, motifs, ...) {
+      matched_patterns <<- motifs
+      matrix(TRUE, nrow = length(glycans), ncol = length(motifs))
+    },
+    .package = "glymotif"
+  )
+  db <- glyrepr::as_glycan_structure("Gal(b1-3)GalNAc(a1-")
+  attr(db, "confidence") <- 1
+  strucs <- glyrepr::as_glycan_structure(c(
+    rep("Hex(??-?)HexNAc(??-", 100),
+    "HexNAc(??-",
+    NA
+  ))
+
+  enhance_struc(strucs, db = db, return_best = TRUE)
+
+  expect_equal(
+    as.character(matched_patterns),
+    c("Hex(??-?)HexNAc(??-", "HexNAc(??-")
+  )
+})
+
 test_that("enhance_struc with return_best=TRUE filters enhanced structures by confidence", {
   db <- glyrepr::as_glycan_structure(c(
     "Gal(b1-3)GalNAc(a1-",

--- a/tests/testthat/test-mz-to-comp.R
+++ b/tests/testthat/test-mz-to-comp.R
@@ -75,6 +75,38 @@ test_that("mz_to_comp works for a simple two m/z case", {
   expect_equal(result, expected)
 })
 
+test_that("mz_to_comp preserves duplicated m/z values", {
+  db <- glyrepr::glycan_composition(
+    c(Glc = 2),
+    c(Gal = 2),
+    c(Glc = 1)
+  )
+  attr(db, "confidence") <- c(1, 2, 3)
+  mz <- c(365, 203, 365)
+
+  best <- mz_to_comp(
+    mz,
+    db = db,
+    adduct = "Na+",
+    mass_dict = mass_dict_for_test(),
+    return_best = TRUE
+  )
+  expanded <- mz_to_comp(
+    mz,
+    db = db,
+    adduct = "Na+",
+    mass_dict = mass_dict_for_test(),
+    return_best = FALSE
+  )
+
+  expect_equal(as.character(best), c("Gal(2)", "Glc(1)", "Gal(2)"))
+  expect_equal(expanded$mz, c(365, 365, 203, 365, 365))
+  expect_equal(
+    as.character(expanded$composition),
+    c("Glc(2)", "Gal(2)", "Glc(1)", "Glc(2)", "Gal(2)")
+  )
+})
+
 test_that("mz_to_comp works for custom numeric tol", {
   simple_db <- glyrepr::glycan_composition(c(Hex = 2))
   mz <- c(365.5, 366.5, 366)

--- a/tests/testthat/test-struc-to-glytoucan.R
+++ b/tests/testthat/test-struc-to-glytoucan.R
@@ -33,6 +33,20 @@ test_that("struc_to_glytoucan maps successful responses to accessions", {
   expect_true(all(grepl("iupaccondensed2wurcs", performed_urls, fixed = TRUE)))
 })
 
+test_that("struc_to_glytoucan preserves duplicated structures", {
+  local_mocked_bindings(
+    req_perform = function(req) {
+      glytoucan_response(body = '{"id":"G00005MO"}')
+    },
+    .package = "httr2"
+  )
+  struc <- glyrepr::as_glycan_structure("Man(b1-2)Gal(a1-")
+
+  accessions <- suppressMessages(struc_to_glytoucan(rep(struc, 2)))
+
+  expect_equal(accessions, rep("G00005MO", 2))
+})
+
 test_that("struc_to_glytoucan returns NA for unsuccessful responses", {
   responses <- list(
     glytoucan_response(status_code = 404),


### PR DESCRIPTION
Fixes #19

## Summary
- Match each unique non-missing structure once in `enhance_struc()`.
- Restore duplicated inputs in their original order for best-only and expanded results.
- Add duplicate-input coverage across all vectorized conversion APIs.
- Reference PR #21 in `NEWS.md`.

## Verification
- `devtools::test()` — 357 passed.
- `devtools::check()` — 0 errors, 0 warnings, one environment clock note.
- Repeated-input benchmark: 2.312 seconds for one input and 2.849 seconds for 100 duplicate inputs.