### PR TITLE
Add confidence scores to expanded annotation results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyanno (development version)
 
+* `mz_to_comp()`, `enhance_comp()`, `comp_to_struc()`, and `enhance_struc()`
+  now include a `confidence` column in expanded results for customized
+  prioritization. (#22)
+
 # glyanno 0.6.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `mz_to_comp()`, `enhance_comp()`, `comp_to_struc()`, and `enhance_struc()`
   now include a `confidence` column in expanded results for customized
-  prioritization. (#22)
+  prioritization. (#23)
 
 # glyanno 0.6.0
 

--- a/R/comp-to-struc.R
+++ b/R/comp-to-struc.R
@@ -25,6 +25,8 @@
 #'   A tibble with the following columns:
 #'   - `composition`: The glycan compositions, as [glyrepr::glycan_composition()] vector.
 #'   - `structure`: The possible glycan structures, as [glyrepr::glycan_structure()] vector.
+#'   - `confidence`: The database confidence score for each structure, or `NA`
+#'     when no score is available.
 #'     Note that one glycan composition can have multiple rows in the result,
 #'     corresponding to different possible glycan structures.
 #'
@@ -45,7 +47,8 @@ comp_to_struc <- function(comps, db = NULL, return_best = FALSE) {
     }
     return(tibble::tibble(
       composition = glyrepr::glycan_composition(),
-      structure = glyrepr::glycan_structure()
+      structure = glyrepr::glycan_structure(),
+      confidence = numeric()
     ))
   }
 
@@ -77,7 +80,7 @@ comp_to_struc <- function(comps, db = NULL, return_best = FALSE) {
   db_df <- tibble::tibble(
     composition = db_index$composition,
     structure = db,
-    confidence = attr(db, "confidence")
+    confidence = attr(db, "confidence") %||% NA_real_
   )
   comps_df <- tibble::tibble(
     composition = comp_keys,

--- a/R/enhance-comp.R
+++ b/R/enhance-comp.R
@@ -27,6 +27,8 @@
 #'   A tibble with the following columns:
 #'   - `raw`: The original compositions.
 #'   - `enhanced`: The enhanced compositions.
+#'   - `confidence`: The database confidence score for each enhanced
+#'     composition, or `NA` when no score is available.
 #'     Note that one `raw` composition can have different `enhanced` compositions
 #'     as multiple rows in the result.
 #'
@@ -49,7 +51,8 @@ enhance_comp <- function(comps, db = NULL, return_best = FALSE) {
     }
     return(tibble::tibble(
       raw = glyrepr::glycan_composition(),
-      enhanced = glyrepr::glycan_composition()
+      enhanced = glyrepr::glycan_composition(),
+      confidence = numeric()
     ))
   }
 
@@ -106,7 +109,8 @@ enhance_comp <- function(comps, db = NULL, return_best = FALSE) {
     }
     res <- tibble::tibble(
       raw = comps,
-      enhanced = comps
+      enhanced = comps,
+      confidence = NA_real_
     )
   }
   res

--- a/R/enhance-struc.R
+++ b/R/enhance-struc.R
@@ -25,6 +25,8 @@
 #'   A tibble with the following columns:
 #'   - `raw`: The original glycan structures.
 #'   - `enhanced`: The enhanced glycan structures.
+#'   - `confidence`: The database confidence score for each enhanced
+#'     structure, or `NA` when no score is available.
 #'     Note that one `raw` glycan structure can have different `enhanced` glycan structures
 #'     as multiple rows in the result.
 #'
@@ -59,7 +61,8 @@ enhance_struc <- function(
     }
     return(tibble::tibble(
       raw = glyrepr::glycan_structure(),
-      enhanced = glyrepr::glycan_structure()
+      enhanced = glyrepr::glycan_structure(),
+      confidence = numeric()
     ))
   }
 
@@ -69,7 +72,8 @@ enhance_struc <- function(
     }
     return(tibble::tibble(
       raw = strucs,
-      enhanced = strucs
+      enhanced = strucs,
+      confidence = NA_real_
     ))
   }
 
@@ -90,7 +94,10 @@ enhance_struc <- function(
 
   if (struc_rank >= target_rank) {
     res <- strucs_df |>
-      dplyr::mutate(enhanced = .data$raw)
+      dplyr::mutate(
+        enhanced = .data$raw,
+        confidence = NA_real_
+      )
   } else {
     to_enhance <- strucs_df$raw
     is_missing <- is.na(to_enhance)
@@ -126,7 +133,8 @@ enhance_struc <- function(
       res <- tibble::tibble(
         raw = to_enhance,
         enhanced = best_matches[unique_ids],
-        row_id = strucs_df$row_id
+        row_id = strucs_df$row_id,
+        confidence = NA_real_
       )
     } else {
       # Restore the matches for each original occurrence of a unique pattern.
@@ -135,14 +143,18 @@ enhance_struc <- function(
           return(tibble::tibble(
             raw = to_enhance[integer(0)],
             enhanced = db[integer(0)],
-            row_id = integer(0)
+            row_id = integer(0),
+            confidence = numeric(0)
           ))
         }
         db_ids <- which(matches[, unique_ids[[i]]])
         tibble::tibble(
           raw = rep(to_enhance[i], length(db_ids)),
           enhanced = db[db_ids],
-          row_id = rep(strucs_df$row_id[[i]], length(db_ids))
+          row_id = rep(strucs_df$row_id[[i]], length(db_ids)),
+          confidence = (attr(db, "confidence") %||% rep(NA_real_, length(db)))[
+            db_ids
+          ]
         )
       })
     }
@@ -150,13 +162,14 @@ enhance_struc <- function(
 
   res <- res |>
     dplyr::arrange(.data$row_id) |>
-    dplyr::select(all_of(c("raw", "enhanced", "row_id")))
+    dplyr::select(all_of(c("raw", "enhanced", "confidence", "row_id")))
 
   # Handle empty result
   if (nrow(res) == 0) {
     res <- tibble::tibble(
       raw = glyrepr::glycan_structure(),
       enhanced = glyrepr::glycan_structure(),
+      confidence = numeric(0),
       row_id = integer(0)
     )
   }

--- a/R/mz-to-comp.R
+++ b/R/mz-to-comp.R
@@ -45,6 +45,8 @@
 #'   A tibble with the following columns:
 #'   - `mz`: The molecule m/z values, same as the input `mz`.
 #'   - `composition`: The possible glycan compositions, as [glyrepr::glycan_composition()] vector.
+#'   - `confidence`: The database confidence score for each composition, or
+#'     `NA` when no score is available.
 #'     Note that one m/z value can have multiple rows in the result,
 #'     corresponding to different possible glycan compositions.
 #'
@@ -73,7 +75,8 @@ mz_to_comp <- function(
     }
     return(tibble::tibble(
       mz = numeric(0),
-      composition = glyrepr::glycan_composition()
+      composition = glyrepr::glycan_composition(),
+      confidence = numeric()
     ))
   }
   checkmate::assert(
@@ -148,9 +151,11 @@ mz_to_comp <- function(
     unname(db[full_ids])
   } else {
     match_counts <- lengths(match_ids)
+    matched_ids <- unlist(match_ids, use.names = FALSE)
     tibble::tibble(
       mz = rep(mz_to_process, match_counts),
-      composition = db[unlist(match_ids, use.names = FALSE)]
+      composition = db[matched_ids],
+      confidence = (confidences %||% rep(NA_real_, length(db)))[matched_ids]
     )
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -188,7 +188,7 @@
     res |>
       dplyr::filter(!is.na(.data[[new_col]])) |>
       dplyr::arrange(.data$row_id) |>
-      dplyr::select(all_of(c(raw_col, new_col)))
+      dplyr::select(all_of(c(raw_col, new_col, "confidence")))
   }
 }
 

--- a/man/comp_to_struc.Rd
+++ b/man/comp_to_struc.Rd
@@ -33,6 +33,8 @@ A tibble with the following columns:
 \itemize{
 \item \code{composition}: The glycan compositions, as \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}} vector.
 \item \code{structure}: The possible glycan structures, as \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector.
+\item \code{confidence}: The database confidence score for each structure, or \code{NA}
+when no score is available.
 Note that one glycan composition can have multiple rows in the result,
 corresponding to different possible glycan structures.
 }

--- a/man/enhance_comp.Rd
+++ b/man/enhance_comp.Rd
@@ -33,6 +33,8 @@ A tibble with the following columns:
 \itemize{
 \item \code{raw}: The original compositions.
 \item \code{enhanced}: The enhanced compositions.
+\item \code{confidence}: The database confidence score for each enhanced
+composition, or \code{NA} when no score is available.
 Note that one \code{raw} composition can have different \code{enhanced} compositions
 as multiple rows in the result.
 }

--- a/man/enhance_struc.Rd
+++ b/man/enhance_struc.Rd
@@ -29,6 +29,8 @@ A tibble with the following columns:
 \itemize{
 \item \code{raw}: The original glycan structures.
 \item \code{enhanced}: The enhanced glycan structures.
+\item \code{confidence}: The database confidence score for each enhanced
+structure, or \code{NA} when no score is available.
 Note that one \code{raw} glycan structure can have different \code{enhanced} glycan structures
 as multiple rows in the result.
 }

--- a/man/mz_to_comp.Rd
+++ b/man/mz_to_comp.Rd
@@ -54,6 +54,8 @@ A tibble with the following columns:
 \itemize{
 \item \code{mz}: The molecule m/z values, same as the input \code{mz}.
 \item \code{composition}: The possible glycan compositions, as \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}} vector.
+\item \code{confidence}: The database confidence score for each composition, or
+\code{NA} when no score is available.
 Note that one m/z value can have multiple rows in the result,
 corresponding to different possible glycan compositions.
 }

--- a/tests/testthat/test-comp-to-struc.R
+++ b/tests/testthat/test-comp-to-struc.R
@@ -9,7 +9,8 @@ test_that("comp_to_struc works for generic db and generic comps", {
     dplyr::mutate(structure = as.character(structure))
   expected <- tibble::tibble(
     composition = comps,
-    structure = "Hex(??-?)HexNAc(??-"
+    structure = "Hex(??-?)HexNAc(??-",
+    confidence = NA_real_
   )
   expect_equal(result, expected)
 })
@@ -25,7 +26,8 @@ test_that("comp_to_struc works for concrete db and generic comps", {
     dplyr::mutate(structure = as.character(structure))
   expected <- tibble::tibble(
     composition = comps,
-    structure = c("Gal(b1-3)GalNAc(a1-", "Gal(b1-4)GalNAc(a1-")
+    structure = c("Gal(b1-3)GalNAc(a1-", "Gal(b1-4)GalNAc(a1-"),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -50,7 +52,8 @@ test_that("comp_to_struc works for concrete db and concrete comps", {
     dplyr::mutate(structure = as.character(structure))
   expected <- tibble::tibble(
     composition = comps,
-    structure = c("Gal(b1-3)GalNAc(a1-", "Gal(b1-4)GalNAc(a1-")
+    structure = c("Gal(b1-3)GalNAc(a1-", "Gal(b1-4)GalNAc(a1-"),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -66,7 +69,8 @@ test_that("comp_to_struc works with multiple compositions", {
     dplyr::mutate(structure = as.character(structure))
   expected <- tibble::tibble(
     composition = comps,
-    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-")
+    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-"),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -82,7 +86,8 @@ test_that("comp_to_struc works with different composition types", {
     dplyr::mutate(structure = as.character(structure))
   expected <- tibble::tibble(
     composition = glyrepr::as_glycan_composition(comps),
-    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-")
+    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-"),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -103,7 +108,8 @@ test_that("comp_to_struc handles duplicate compositions", {
   best <- comp_to_struc(comps, db, return_best = TRUE)
   expected <- tibble::tibble(
     composition = comps,
-    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-", "Hex(??-?)HexNAc(??-")
+    structure = c("Hex(??-?)HexNAc(??-", "HexNAc(??-", "Hex(??-?)HexNAc(??-"),
+    confidence = c(1, 2, 1)
   )
   expect_equal(result, expected)
   expect_equal(as.character(best), expected$structure)
@@ -115,7 +121,8 @@ test_that("comp_to_struc accepts empty compositions", {
   result <- comp_to_struc(comps, db)
   expected <- tibble::tibble(
     composition = glyrepr::glycan_composition(),
-    structure = glyrepr::glycan_structure()
+    structure = glyrepr::glycan_structure(),
+    confidence = numeric()
   )
   expect_equal(result, expected)
 })
@@ -196,8 +203,8 @@ test_that("comp_to_struc works with db=NULL (regression: confidences undefined)"
   expect_no_error(
     result <- comp_to_struc(comps, db = NULL, return_best = FALSE)
   )
-  # Result should be a tibble with composition and structure columns
-  expect_named(result, c("composition", "structure"))
+  expect_named(result, c("composition", "structure", "confidence"))
+  expect_false(all(is.na(result$confidence)))
   # Should have at least one match from default glydb
   expect_gt(nrow(result), 0)
 })

--- a/tests/testthat/test-enhance-comp.R
+++ b/tests/testthat/test-enhance-comp.R
@@ -5,7 +5,11 @@ test_that("enhance_comp works for a basic case", {
     c(Glc = 1, GalNAc = 1)
   )
   result <- enhance_comp(comps, db)
-  expected <- tibble::tibble(raw = comps, enhanced = db)
+  expected <- tibble::tibble(
+    raw = comps,
+    enhanced = db,
+    confidence = c(NA_real_, NA_real_)
+  )
   expect_equal(result, expected)
 })
 
@@ -18,7 +22,8 @@ test_that("enhance_comp accepts character input", {
     enhanced = glyrepr::glycan_composition(
       c(Gal = 1, GalNAc = 1),
       c(Glc = 1, GalNAc = 1)
-    )
+    ),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -32,7 +37,8 @@ test_that("enhance_comp works with empty input", {
   result <- enhance_comp(comps, db)
   expected <- tibble::tibble(
     raw = glyrepr::glycan_composition(),
-    enhanced = glyrepr::glycan_composition()
+    enhanced = glyrepr::glycan_composition(),
+    confidence = numeric()
   )
   expect_equal(result, expected)
 })
@@ -49,7 +55,8 @@ test_that("enhance_comp works with generic and compositions", {
     enhanced = glyrepr::as_glycan_composition(c(
       "Glc(1)GalNAc(1)",
       "Glc(1)GlcNAc(1)"
-    ))
+    )),
+    confidence = c(NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -75,6 +82,7 @@ test_that("enhance_comp preserves duplicated compositions", {
     as.character(expanded$enhanced),
     c("Glc(2)", "Gal(2)", "Glc(1)", "Glc(2)", "Gal(2)")
   )
+  expect_equal(expanded$confidence, c(1, 2, 3, 1, 2))
 })
 
 test_that("enhance_comp works with concrete compositions", {
@@ -83,7 +91,8 @@ test_that("enhance_comp works with concrete compositions", {
   result <- enhance_comp(comps, db)
   expected <- tibble::tibble(
     raw = glyrepr::as_glycan_composition("Gal(1)GalNAc(1)"),
-    enhanced = glyrepr::as_glycan_composition("Gal(1)GalNAc(1)")
+    enhanced = glyrepr::as_glycan_composition("Gal(1)GalNAc(1)"),
+    confidence = NA_real_
   )
   expect_equal(result, expected)
 })
@@ -141,8 +150,8 @@ test_that("enhance_comp works with db=NULL (regression: confidences undefined)",
   expect_no_error(
     result <- enhance_comp(comps, db = NULL, return_best = FALSE)
   )
-  # Result should be a tibble with raw and enhanced columns
-  expect_named(result, c("raw", "enhanced"))
+  expect_named(result, c("raw", "enhanced", "confidence"))
+  expect_false(all(is.na(result$confidence)))
 })
 
 test_that("enhance_comp reuses the prepared default database", {

--- a/tests/testthat/test-enhance-struc.R
+++ b/tests/testthat/test-enhance-struc.R
@@ -90,7 +90,8 @@ test_that("enhance_struc accepts empty structures", {
     res,
     tibble::tibble(
       raw = glyrepr::glycan_structure(),
-      enhanced = glyrepr::glycan_structure()
+      enhanced = glyrepr::glycan_structure(),
+      confidence = numeric()
     )
   )
 })
@@ -107,7 +108,8 @@ test_that("enhance_struc accepts all-NA structures", {
     res,
     tibble::tibble(
       raw = input_na,
-      enhanced = input_na
+      enhanced = input_na,
+      confidence = c(NA_real_, NA_real_)
     )
   )
   expect_equal(best, input_na)
@@ -181,6 +183,7 @@ test_that("enhance_struc restores repeated and missing inputs", {
       "Gal(b1-4)GalNAc(a1-"
     )
   )
+  expect_equal(expanded$confidence, c(1, 2, 3, 1, 2))
 })
 
 test_that("enhance_struc matches each unique non-missing input once", {
@@ -284,8 +287,8 @@ test_that("enhance_struc works with db=NULL (regression: confidences undefined)"
       return_best = FALSE
     )
   )
-  # Result should be a tibble with raw and enhanced columns
-  expect_named(result, c("raw", "enhanced"))
+  expect_named(result, c("raw", "enhanced", "confidence"))
+  expect_false(all(is.na(result$confidence)))
   # Should have at least one match from default glydb
   expect_gt(nrow(result), 0)
 })

--- a/tests/testthat/test-mz-to-comp.R
+++ b/tests/testthat/test-mz-to-comp.R
@@ -51,6 +51,7 @@ test_that("mz_to_comp works for a simple one m/z case", {
   expected <- tibble::tibble(
     mz = 365,
     composition = glyrepr::glycan_composition(c(Hex = 2)),
+    confidence = NA_real_
   )
   expect_equal(result, expected)
 })
@@ -71,6 +72,7 @@ test_that("mz_to_comp works for a simple two m/z case", {
   expected <- tibble::tibble(
     mz = c(203, 365, 365),
     composition = simple_db[1:3],
+    confidence = c(NA_real_, NA_real_, NA_real_)
   )
   expect_equal(result, expected)
 })
@@ -105,6 +107,7 @@ test_that("mz_to_comp preserves duplicated m/z values", {
     as.character(expanded$composition),
     c("Glc(2)", "Gal(2)", "Glc(1)", "Glc(2)", "Gal(2)")
   )
+  expect_equal(expanded$confidence, c(1, 2, 3, 1, 2))
 })
 
 test_that("mz_to_comp works for custom numeric tol", {
@@ -120,7 +123,8 @@ test_that("mz_to_comp works for custom numeric tol", {
     ),
     tibble::tibble(
       mz = 365.5,
-      composition = glyrepr::glycan_composition(c(Hex = 2))
+      composition = glyrepr::glycan_composition(c(Hex = 2)),
+      confidence = NA_real_
     )
   )
 })
@@ -137,7 +141,11 @@ test_that("mz_to_comp works for custom ppm tol", {
       adduct = "Na+",
       mass_dict = mass_dict_for_test()
     ),
-    tibble::tibble(mz = c(mz2), composition = simple_db)
+    tibble::tibble(
+      mz = c(mz2),
+      composition = simple_db,
+      confidence = NA_real_
+    )
   )
 })
 
@@ -156,7 +164,8 @@ test_that("mz_to_comp handles db with glycans that cannot be calculated m/z valu
     result,
     tibble::tibble(
       mz = 203,
-      composition = glyrepr::glycan_composition(c(Glc = 1))
+      composition = glyrepr::glycan_composition(c(Glc = 1)),
+      confidence = NA_real_
     )
   )
 })
@@ -169,7 +178,11 @@ test_that("mz_to_comp returns empty tibble with empty mz", {
       adduct = "Na+",
       mass_dict = mass_dict_for_test()
     ),
-    tibble::tibble(mz = numeric(0), composition = glyrepr::glycan_composition())
+    tibble::tibble(
+      mz = numeric(0),
+      composition = glyrepr::glycan_composition(),
+      confidence = numeric()
+    )
   )
 })
 
@@ -183,7 +196,8 @@ test_that("mz_to_comp returns handles NA", {
     ),
     tibble::tibble(
       mz = 365,
-      composition = glyrepr::glycan_composition(c(Hex = 2))
+      composition = glyrepr::glycan_composition(c(Hex = 2)),
+      confidence = NA_real_
     )
   )
 })
@@ -244,6 +258,7 @@ test_that("mz_to_comp accepts glycan composition strings as db", {
   expected <- tibble::tibble(
     mz = 365,
     composition = glyrepr::glycan_composition(c(Hex = 2)),
+    confidence = NA_real_
   )
   expect_equal(result, expected)
 })
@@ -343,8 +358,8 @@ test_that("mz_to_comp works with db=NULL (regression: confidences undefined)", {
       return_best = FALSE
     )
   )
-  # Result should be a tibble with mz and composition columns
-  expect_named(result, c("mz", "composition"))
+  expect_named(result, c("mz", "composition", "confidence"))
+  expect_false(all(is.na(result$confidence)))
   # Should have at least one match from default glydb
   expect_gt(nrow(result), 0)
 })


### PR DESCRIPTION
Closes #22

## Summary

- Add a `confidence` column to expanded results from `mz_to_comp()`, `enhance_comp()`, `comp_to_struc()`, and `enhance_struc()`.
- Propagate scores from the supplied glycan database.
- Use `NA` for custom databases without scores and pass-through results.
- Keep `return_best = TRUE` vector behavior unchanged.

## Verification

```r
db <- glydb::glydb_compositions()
result <- glyanno::enhance_comp("Hex(5)HexNAc(2)", db)
result[, c("raw", "enhanced", "confidence")]
```

- `devtools::test()`: 364 passed
- `pkgdown::check_pkgdown()`: no problems
- `devtools::check(document = FALSE, manual = FALSE, cran = FALSE)`: 0 errors, 0 warnings, 0 notes